### PR TITLE
Add environment file templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,13 @@ controlai-vendas/
 
 ## ⚙️ Configuração de Variáveis de Ambiente
 
-Na raiz de cada serviço (backend e frontend), crie um arquivo `.env` com as chaves abaixo.
+Cada serviço possui um arquivo `.env.example` com todas as chaves necessárias. Copie-o para `.env` e ajuste os valores conforme seu ambiente.
 
 ### Backend (`backend/.env`)
+
+```bash
+cp backend/.env.example backend/.env
+```
 
 env
 PORT=3001
@@ -41,6 +45,10 @@ REDIS_URL=<sua_url_redis>  # ex: redis://localhost:6379
 NODE_ENV=development
 
 ### Frontend (`frontend/.env`)
+
+```bash
+cp frontend/.env.example frontend/.env
+```
 
 env
 VITE_API_URL=<http://localhost:3001/api>
@@ -221,10 +229,12 @@ git clone https://github.com/seu-usuario/controleai-vendas.git
 cd controleai-vendas
 
 
-2. Configure as variáveis de ambiente:
-bash
-cp .env.example .env
-# Edite o arquivo .env com suas configurações
+2. Configure as variáveis de ambiente de cada serviço:
+```bash
+cp backend/.env.example backend/.env
+cp frontend/.env.example frontend/.env
+```
+# Edite os arquivos `.env` com suas configurações
 
 
 3. Inicie os containers:
@@ -245,10 +255,12 @@ bash
 npm install
 
 
-3. Configure as variáveis de ambiente:
-bash
-cp .env.example .env
-# Edite o arquivo .env com suas configurações
+3. Configure as variáveis de ambiente de cada serviço:
+```bash
+cp backend/.env.example backend/.env
+cp frontend/.env.example frontend/.env
+```
+# Edite os arquivos `.env` com suas configurações
 
 
 4. Inicie o servidor:

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,5 @@
+PORT=3001
+MONGODB_URI=mongodb://localhost:27017/controlai_vendas
+JWT_SECRET=your-secret-key
+REDIS_URL=redis://localhost:6379
+NODE_ENV=development

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3001/api


### PR DESCRIPTION
## Summary
- provide env template for backend and frontend
- document copying these .env.example files in README

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685043c134748330b68c2d3f4c07302c