### PR TITLE
Add instructions for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,22 @@ Workflow configurado em `.github/workflows/ci.yml`:
 
 ---
 
+## 🧪 Executar Testes Localmente
+
+Instale as dependências com o comando recomendado e rode a suíte de testes:
+
+```bash
+npm ci --legacy-peer-deps
+npm test
+```
+
+Se necessário, crie um arquivo `.env.test` contendo variáveis como `SMTP_HOST`,
+`SMTP_USER`, `TWILIO_ACCOUNT_SID`, `FIREBASE_PROJECT_ID`, `REDIS_HOST` etc.,
+utilizadas nos testes do backend. Valores padrão são definidos em
+`backend/src/tests/setup.ts`.
+
+---
+
 ## Contribuição
 
 1. Fork deste repositório


### PR DESCRIPTION
## Summary
- document how to install deps with `npm ci --legacy-peer-deps`
- add section on running `npm test` and using `.env.test`

## Testing
- `npm ci --legacy-peer-deps`
- `npm test` *(fails: TextEncoder is not defined, winston.addColors is not a function, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6850dabe80e883309475ae932454c9b9