### PR TITLE
Fix backend tsconfig syntax

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-
     "target": "ES2020",
     "module": "CommonJS",
     "lib": ["ES2020"],
@@ -17,7 +16,7 @@
     "allowJs": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
 
     "sourceMap": true,
     "declaration": true,
@@ -26,8 +25,7 @@
       "@/*": ["src/*"]
     },
     "typeRoots": ["./node_modules/@types", "./src/types"]
-
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]
-} 
+}


### PR DESCRIPTION
## Summary
- correct malformed `backend/tsconfig.json` with missing comma and stray text

## Testing
- `npx ts-node --project backend/tsconfig.json -e "console.log('test')"

------
https://chatgpt.com/codex/tasks/task_e_68510a84171883308f230d6cc6ac8967