### PR TITLE
Fix MONGODB_URI usage

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,5 @@
 PORT=3001
+# Example MongoDB connection string
 MONGODB_URI=mongodb://localhost:27017/controlai_vendas
 JWT_SECRET=your-secret-key
 REDIS_URL=redis://localhost:6379

--- a/backend/README.md
+++ b/backend/README.md
@@ -77,7 +77,7 @@ A robust sales management system backend built with Node.js, Express, TypeScript
    ```env
    NODE_ENV=development
    PORT=5000
-   MONGODB_URI=mongodb://localhost:27017/controlai_vendas
+   MONGODB_URI=mongodb://localhost:27017/controlai_vendas  # or your MongoDB URI
    JWT_SECRET=your-secret-key
    JWT_EXPIRE=24h
    ```

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,7 +21,8 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
 // Conexão com MongoDB
-const MONGODB_URI = 'mongodb+srv://sarahjenniferalvesknupp:Brocolis3388@controlai.vj9ztrr.mongodb.net/controlai_vendas?retryWrites=true&w=majority';
+const MONGODB_URI = process.env.MONGODB_URI ||
+  'mongodb://localhost:27017/controlai_vendas';
 
 async function connectDB() {
   try {

--- a/src/test-connection.ts
+++ b/src/test-connection.ts
@@ -6,7 +6,8 @@ dotenv.config();
 // Configuração para evitar warnings do Mongoose
 mongoose.set('strictQuery', true);
 
-const MONGODB_URI = 'mongodb+srv://sarahjenniferalvesknupp:Brocolis3388@controlai.vj9ztrr.mongodb.net/controlai_vendas?retryWrites=true&w=majority';
+const MONGODB_URI = process.env.MONGODB_URI ||
+  'mongodb://localhost:27017/controlai_vendas';
 
 async function testConnection() {
   try {


### PR DESCRIPTION
## Summary
- use env var in server connection string
- use env var in test connection script
- document MongoDB URI in backend docs and env example

## Testing
- `npm test` *(fails: TextEncoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68510edac11c8330b3901dddbbc6e547