### PR TITLE
Add mongoose import

### DIFF
--- a/src/scripts/setup-database.ts
+++ b/src/scripts/setup-database.ts
@@ -1,4 +1,5 @@
 import dotenv from 'dotenv';
+import mongoose from 'mongoose';
 import { connectDatabase, getDatabaseStatus } from '../config/database';
 import { logger } from '../utils/logger';
 


### PR DESCRIPTION
## Summary
- add missing `mongoose` import to the database setup script

## Testing
- `npx tsc --esModuleInterop --moduleResolution node --target ES2020 --lib ES2020,DOM --noEmit src/scripts/setup-database.ts`

------
https://chatgpt.com/codex/tasks/task_e_685111cad9988330ae4eedcccf0cea3e