### PR TITLE
fix env handling for Mongo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example environment variables for root scripts
+MONGODB_URI=mongodb://localhost:27017/controlai_vendas

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,7 +21,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
 // Conexão com MongoDB
-const MONGODB_URI = process.env.MONGODB_URI ||
+const MONGODB_URI = process.env.MONGODB_URI ??
   'mongodb://localhost:27017/controlai_vendas';
 
 async function connectDB() {

--- a/src/test-connection.ts
+++ b/src/test-connection.ts
@@ -6,7 +6,7 @@ dotenv.config();
 // Configuração para evitar warnings do Mongoose
 mongoose.set('strictQuery', true);
 
-const MONGODB_URI = process.env.MONGODB_URI ||
+const MONGODB_URI = process.env.MONGODB_URI ??
   'mongodb://localhost:27017/controlai_vendas';
 
 async function testConnection() {

--- a/test-connection.ts
+++ b/test-connection.ts
@@ -6,7 +6,7 @@ dotenv.config();
 // Configuração para evitar warnings do Mongoose
 mongoose.set('strictQuery', true);
 
-const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/controlai_vendas';
+const MONGODB_URI = process.env.MONGODB_URI ?? 'mongodb://localhost:27017/controlai_vendas';
 
 async function testConnection() {
   try {


### PR DESCRIPTION
## Summary
- read MONGODB_URI from environment in server scripts with localhost fallback
- document MONGODB_URI in new `.env.example`

## Testing
- `npm test` *(fails: TextEncoder is not defined and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_685111d1aae88330969e8b0ab54bf00d