### PR TITLE
Add type-check npm script

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Se necessário, crie `.env.test` com variáveis como `SMTP_HOST`, `SMTP_USER`, `
 - `npm start` – executa o servidor compilado
 - `npm test` – executa a suíte de testes
 - `npm run lint` – roda o ESLint
+- `npm run type-check` – verifica os tipos TypeScript sem gerar arquivos
 
 ## ✅ CI/CD
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,7 @@
         "supertest": "^6.3.4",
         "ts-jest": "^29.1.2",
         "ts-node-dev": "^2.0.0",
-        "typescript": "^5.8.3"
+        "typescript": "5.4.5"
       }
     },
     "engines": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "db:seed": "ts-node backend/src/database/seeds/index.ts",
     "db:atlas": "ts-node src/scripts/setup-atlas.ts",
     "db:test-atlas": "ts-node src/scripts/test-atlas-connection.ts",
-    "db:setup-backups": "ts-node src/scripts/setup-backups.ts"
+    "db:setup-backups": "ts-node src/scripts/setup-backups.ts",
+    "type-check": "tsc --noEmit --skipLibCheck"
   },
   "keywords": [],
   "author": "",
@@ -115,7 +116,7 @@
     "supertest": "^6.3.4",
     "ts-jest": "^29.1.2",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.3.3",
+    "typescript": "5.4.5",
 
     "jest-environment-jsdom": "^29.7.0",
     "lint-staged": "^15.2.2",


### PR DESCRIPTION
## Summary
- add a `type-check` script calling `tsc`
- document the new command in the README
- lock TypeScript at 5.4.5 so the check runs correctly

## Testing
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_68512803b9c08330bdb3b4632b1bb591