### PR TITLE
Fix TypeScript version mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
         "@types/react-dropzone": "^5.1.0",
         "@types/supertest": "^6.0.2",
         "@types/swagger-jsdoc": "^6.0.4",
-        "@types/swagger-ui-express": "^4.1.6",
+        "@types/swagger-ui-express": "^4.1.8",
         "@types/tesseract.js": "^2.0.0",
         "@types/uuid": "^9.0.8",
         "@typescript-eslint/eslint-plugin": "^7.0.1",
@@ -96,13 +96,11 @@
         "jest-environment-jsdom": "^29.7.0",
         "lint-staged": "^15.2.2",
         "mongodb-memory-server": "^9.1.6",
-        "normalize-path": "^3.0.0",
-        "pkg-dir": "^9.0.0",
         "prettier": "^3.2.5",
         "supertest": "^6.3.4",
         "ts-jest": "^29.1.2",
         "ts-node-dev": "^2.0.0",
-        "typescript": "5.4.5"
+        "typescript": "5.8.3"
       }
     },
     "engines": {
@@ -8117,19 +8115,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/find-up-simple": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
-      "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/find-up/node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -12609,23 +12594,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/pkg-dir": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-9.0.0.tgz",
-      "integrity": "sha512-BMmxOuokumBehLGYwCKMBJxpAGSBbvGTtDn1yUV9UpCAvC4F7UWHoPTGSDGPV8eQPkYq/G8b0g1W5vIc5K/EhA==",
-      "deprecated": "Renamed to `package-directory`.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-up-simple": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/png-js": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "supertest": "^6.3.4",
     "ts-jest": "^29.1.2",
     "ts-node-dev": "^2.0.0",
-    "typescript": "5.4.5",
+    "typescript": "5.8.3",
 
     "jest-environment-jsdom": "^29.7.0",
     "lint-staged": "^15.2.2",


### PR DESCRIPTION
## Summary
- bump TypeScript in `package.json`
- regenerate `package-lock.json`

## Testing
- `npm ci --legacy-peer-deps`
- `npm test` *(fails: cannot find some modules, but Jest ran)*

------
https://chatgpt.com/codex/tasks/task_e_68517f286fb883308c33a85b6384a418