### PR TITLE
Fix mongoose import order

### DIFF
--- a/src/scripts/setup-database.ts
+++ b/src/scripts/setup-database.ts
@@ -1,5 +1,5 @@
-import dotenv from 'dotenv';
 import mongoose from 'mongoose';
+import dotenv from 'dotenv';
 import { connectDatabase, getDatabaseStatus } from '../config/database';
 import { logger } from '../utils/logger';
 


### PR DESCRIPTION
## Summary
- keep mongoose import as the first import in the setup script

## Testing
- `npx tsc src/scripts/setup-database.ts --lib ES2022 --module Node16 --moduleResolution Node16 --esModuleInterop --skipLibCheck --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6851193eaf9c8330b7124544cf7c113f