### PR TITLE
Add types to express route handlers

### DIFF
--- a/backend/src/routes/audit.routes.ts
+++ b/backend/src/routes/audit.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { AuditController } from '../controllers/audit.controller';
 import { authenticate } from '../middleware/auth.middleware';
 import { authorize } from '../middleware/authorize.middleware';
@@ -15,7 +15,7 @@ router.get(
   authenticate,
   authorize([UserRole.ADMIN]),
   validate(auditValidation.getAuditLogs),
-  (req, res, next): void => {
+  (req: Request, res: Response, next: NextFunction): void => {
     auditController.getAuditLogs(req, res, next);
   }
 );
@@ -34,7 +34,7 @@ router.get(
   authenticate,
   authorize([UserRole.ADMIN]),
   validate(auditValidation.getAuditLog),
-  (req, res, next): void => {
+  (req: Request, res: Response, next: NextFunction): void => {
     auditController.getAuditLog(req, res, next);
   }
 );
@@ -45,7 +45,7 @@ router.delete(
   authenticate,
   authorize([UserRole.ADMIN]),
   validate(auditValidation.deleteAuditLog),
-  (req, res, next): void => {
+  (req: Request, res: Response, next: NextFunction): void => {
     auditController.deleteAuditLog(req, res, next);
   }
 );
@@ -56,7 +56,7 @@ router.post(
   authenticate,
   authorize([UserRole.ADMIN]),
   validate(auditValidation.clearAuditLogs),
-  (req, res, next): void => {
+  (req: Request, res: Response, next: NextFunction): void => {
     auditController.clearAuditLogs(req, res, next);
   }
 );

--- a/backend/src/routes/backup.routes.ts
+++ b/backend/src/routes/backup.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { BackupController } from '../controllers/backup.controller';
 import { validateRequest } from '../middleware/validation';
 import { backupValidation } from '../validations/backup.validation';
@@ -10,27 +10,27 @@ const router = Router();
 const backupController = new BackupController();
 
 // Create backup
-router.post('/create', authenticate, authorize([UserRole.ADMIN]), (req, res, next): void => {
+router.post('/create', authenticate, authorize([UserRole.ADMIN]), (req: Request, res: Response, next: NextFunction): void => {
   backupController.createBackup(req, res, next);
 });
 
 // Restore backup
-router.post('/restore', authenticate, authorize([UserRole.ADMIN]), (req, res, next): void => {
+router.post('/restore', authenticate, authorize([UserRole.ADMIN]), (req: Request, res: Response, next: NextFunction): void => {
   backupController.restoreBackup(req, res, next);
 });
 
 // List backups
-router.get('/', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER]), (req, res, next): void => {
+router.get('/', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER]), (req: Request, res: Response, next: NextFunction): void => {
   backupController.listBackups(req, res, next);
 });
 
 // Delete backup
-router.delete('/:id', authenticate, authorize([UserRole.ADMIN]), (req, res, next): void => {
+router.delete('/:id', authenticate, authorize([UserRole.ADMIN]), (req: Request, res: Response, next: NextFunction): void => {
   backupController.deleteBackup(req, res, next);
 });
 
 // Get backup status
-router.get('/status', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER]), (req, res, next): void => {
+router.get('/status', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER]), (req: Request, res: Response, next: NextFunction): void => {
   backupController.getBackupStatus(req, res, next);
 });
 

--- a/backend/src/routes/customer.routes.ts
+++ b/backend/src/routes/customer.routes.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { Request, Response, NextFunction } from 'express';
 import { protect, authorize } from '../middleware/auth.middleware';
 import { UserRole } from '../models/User';
 import { validate } from '../middleware/validation/validate';
@@ -33,29 +33,29 @@ router.use(protect);
 
 
 // Base routes
-router.get('/', validate(getCustomersValidation), async (req, res, next): Promise<void> => {
+router.get('/', validate(getCustomersValidation), async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   await getCustomers(req, res, next);
 });
 
-router.post('/', validate(createCustomerValidation), async (req, res, next): Promise<void> => {
+router.post('/', validate(createCustomerValidation), async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   await createCustomer(req, res, next);
 });
 
 // Customer-specific routes
-router.get('/:customerId', validate(customerIdSchema), async (req, res, next): Promise<void> => {
+router.get('/:customerId', validate(customerIdSchema), async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   await getCustomer(req, res, next);
 });
 
-router.put('/:customerId', validate({ ...customerIdSchema, body: updateCustomerValidation }), async (req, res, next): Promise<void> => {
+router.put('/:customerId', validate({ ...customerIdSchema, body: updateCustomerValidation }), async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   await updateCustomer(req, res, next);
 });
 
-router.delete('/:customerId', validate(customerIdSchema), async (req, res, next): Promise<void> => {
+router.delete('/:customerId', validate(customerIdSchema), async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   await deleteCustomer(req, res, next);
 });
 
 // Customer purchases
-router.get('/:customerId/purchases', validate({ ...customerIdSchema, query: getCustomerPurchasesValidation }), async (req, res, next): Promise<void> => {
+router.get('/:customerId/purchases', validate({ ...customerIdSchema, query: getCustomerPurchasesValidation }), async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   await getCustomerPurchases(req, res, next);
 });
 

--- a/backend/src/routes/dashboard.routes.ts
+++ b/backend/src/routes/dashboard.routes.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { Request, Response, NextFunction } from 'express';
 import { protect, authorize } from '../middleware/auth.middleware';
 import { UserRole } from '../models/User';
 import { validate } from '../middleware/validation/validate';
@@ -15,22 +15,22 @@ const router = express.Router();
 router.use(protect);
 
 // Get dashboard statistics
-router.get('/stats', authorize([UserRole.ADMIN, UserRole.MANAGER]), async (req, res, next): Promise<void> => {
+router.get('/stats', authorize([UserRole.ADMIN, UserRole.MANAGER]), async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   await getDashboardStats(req, res, next);
 });
 
 // Get sales overview
-router.get('/sales-overview', authorize([UserRole.ADMIN, UserRole.MANAGER]), async (req, res, next): Promise<void> => {
+router.get('/sales-overview', authorize([UserRole.ADMIN, UserRole.MANAGER]), async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   await getSalesOverview(req, res, next);
 });
 
 // Get top products
-router.get('/top-products', authorize([UserRole.ADMIN, UserRole.MANAGER]), async (req, res, next): Promise<void> => {
+router.get('/top-products', authorize([UserRole.ADMIN, UserRole.MANAGER]), async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   await getTopProducts(req, res, next);
 });
 
 // Get recent sales
-router.get('/recent-sales', authorize([UserRole.ADMIN, UserRole.MANAGER]), async (req, res, next): Promise<void> => {
+router.get('/recent-sales', authorize([UserRole.ADMIN, UserRole.MANAGER]), async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   await getRecentSales(req, res, next);
 });
 

--- a/backend/src/routes/email.routes.ts
+++ b/backend/src/routes/email.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { EmailController } from '../controllers/email.controller';
 import { validateRequest } from '../middleware/validation';
 import { emailValidation } from '../validations/email.validation';
@@ -10,22 +10,22 @@ const router = Router();
 const emailController = new EmailController();
 
 // Send sale receipt
-router.post('/receipt', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER, UserRole.CASHIER]), (req, res, next): void => {
+router.post('/receipt', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER, UserRole.CASHIER]), (req: Request, res: Response, next: NextFunction): void => {
   emailController.sendReceiptEmail(req, res, next);
 });
 
 // Send sales report
-router.post('/report', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER]), (req, res, next): void => {
+router.post('/report', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER]), (req: Request, res: Response, next: NextFunction): void => {
   emailController.sendReportEmail(req, res, next);
 });
 
 // Send low stock alert
-router.post('/low-stock', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER]), (req, res, next): void => {
+router.post('/low-stock', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER]), (req: Request, res: Response, next: NextFunction): void => {
   emailController.sendLowStockAlert(req, res, next);
 });
 
 // Send password reset
-router.post('/reset-password', (req, res, next): void => {
+router.post('/reset-password', (req: Request, res: Response, next: NextFunction): void => {
   emailController.sendPasswordResetEmail(req, res, next);
 });
 

--- a/backend/src/routes/import.routes.ts
+++ b/backend/src/routes/import.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { ImportController } from '../controllers/import.controller';
 import { authenticate } from '../middleware/auth.middleware';
 import { authorize } from '../middleware/authorize.middleware';
@@ -39,15 +39,15 @@ const upload = multer({
 });
 
 // Import routes
-router.post('/', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER]), upload.single('file'), (req, res, next): void => {
+router.post('/', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER]), upload.single('file'), (req: Request, res: Response, next: NextFunction): void => {
   importController.importData(req, res, next);
 });
 
-router.get('/:importId/status', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER]), (req, res, next): void => {
+router.get('/:importId/status', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER]), (req: Request, res: Response, next: NextFunction): void => {
   importController.getImportStatus(req, res, next);
 });
 
-router.delete('/:importId', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER]), (req, res, next): void => {
+router.delete('/:importId', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER]), (req: Request, res: Response, next: NextFunction): void => {
   importController.deleteImport(req, res, next);
 });
 

--- a/backend/src/routes/metrics.routes.ts
+++ b/backend/src/routes/metrics.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { MetricsController } from '../controllers/metrics.controller';
 import { validateRequest } from '../middleware/validation';
 import { metricsValidation } from '../validations/metrics.validation';
@@ -15,7 +15,7 @@ router.post(
   authenticate,
   authorize([UserRole.ADMIN, UserRole.MANAGER]),
   validateRequest(metricsValidation.collectMetrics),
-  (req, res, next): void => {
+  (req: Request, res: Response, next: NextFunction): void => {
     metricsController.collectMetrics(req, res, next);
   }
 );
@@ -25,7 +25,7 @@ router.get(
   '/status',
   authenticate,
   authorize([UserRole.ADMIN, UserRole.MANAGER]),
-  (req, res, next): void => {
+  (req: Request, res: Response, next: NextFunction): void => {
     metricsController.getMetricsStatus(req, res, next);
   }
 );
@@ -44,7 +44,7 @@ router.get(
   authenticate,
   authorize([UserRole.ADMIN]),
   validateRequest(metricsValidation.getUsageMetrics),
-  (req, res, next): void => {
+  (req: Request, res: Response, next: NextFunction): void => {
     metricsController.getUsageMetrics(req, res, next);
   }
 );

--- a/backend/src/routes/notification.routes.ts
+++ b/backend/src/routes/notification.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { NotificationController } from '../controllers/notification.controller';
 import { validateRequest } from '../middleware/validation';
 import { notificationValidation } from '../validations/notification.validation';
@@ -10,27 +10,27 @@ const router = Router();
 const notificationController = new NotificationController();
 
 // Send general notification
-router.post('/send', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER]), (req, res, next): void => {
+router.post('/send', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER]), (req: Request, res: Response, next: NextFunction): void => {
   notificationController.sendNotification(req, res, next);
 });
 
 // Send low stock alert
-router.post('/low-stock', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER]), (req, res, next): void => {
+router.post('/low-stock', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER]), (req: Request, res: Response, next: NextFunction): void => {
   notificationController.sendLowStockAlert(req, res, next);
 });
 
 // Send sales target alert
-router.post('/sales-target', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER]), (req, res, next): void => {
+router.post('/sales-target', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER]), (req: Request, res: Response, next: NextFunction): void => {
   notificationController.sendSalesTargetAlert(req, res, next);
 });
 
 // Send system maintenance notification
-router.post('/maintenance', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER]), (req, res, next): void => {
+router.post('/maintenance', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER]), (req: Request, res: Response, next: NextFunction): void => {
   notificationController.sendMaintenanceNotification(req, res, next);
 });
 
 // Send security alert
-router.post('/security', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER]), (req, res, next): void => {
+router.post('/security', authenticate, authorize([UserRole.ADMIN, UserRole.MANAGER]), (req: Request, res: Response, next: NextFunction): void => {
   notificationController.sendSecurityAlert(req, res, next);
 });
 

--- a/backend/src/routes/ocr.routes.ts
+++ b/backend/src/routes/ocr.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { authenticate } from '../middleware/auth';
 import { validate } from '../middleware/validation';
 import { ocrValidation } from '../validations/ocr.validation';
@@ -7,19 +7,19 @@ import { ocrController } from '../controllers/ocr.controller';
 const router = Router();
 
 // OCR routes
-router.post('/scan', authenticate, (req, res, next): void => {
+router.post('/scan', authenticate, (req: Request, res: Response, next: NextFunction): void => {
   ocrController.scanDocument(req, res, next);
 });
 
-router.post('/process', authenticate, (req, res, next): void => {
+router.post('/process', authenticate, (req: Request, res: Response, next: NextFunction): void => {
   ocrController.processImage(req, res, next);
 });
 
-router.get('/stats', authenticate, (req, res, next): void => {
+router.get('/stats', authenticate, (req: Request, res: Response, next: NextFunction): void => {
   ocrController.getStats(req, res, next);
 });
 
-router.get('/history', authenticate, (req, res, next): void => {
+router.get('/history', authenticate, (req: Request, res: Response, next: NextFunction): void => {
   ocrController.getHistory(req, res, next);
 });
 

--- a/backend/src/routes/pdf.routes.ts
+++ b/backend/src/routes/pdf.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { PDFController } from '../controllers/pdf.controller';
 import { validateRequest } from '../middleware/validation';
 import { pdfValidation } from '../validations/pdf.validation';
@@ -13,7 +13,7 @@ router.get(
   '/receipt/:saleId',
   authenticate,
   authorize(['admin', 'manager', 'cashier']),
-  (req, res, next): void => {
+  (req: Request, res: Response, next: NextFunction): void => {
     pdfController.generateSaleReceipt.bind(pdfController)(req, res, next);
   }
 );
@@ -24,7 +24,7 @@ router.get(
   authenticate,
   authorize(['admin', 'manager']),
   validateRequest(pdfValidation.generateReport),
-  (req, res, next): void => {
+  (req: Request, res: Response, next: NextFunction): void => {
     pdfController.generateSalesReport.bind(pdfController)(req, res, next);
   }
 );

--- a/backend/src/routes/receipt.routes.ts
+++ b/backend/src/routes/receipt.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { ReceiptController } from '../controllers/receipt.controller';
 import { authenticate } from '../middleware/auth';
 import { authorize } from '../middleware/authorization';
@@ -12,7 +12,7 @@ router.get(
   '/:saleId/generate',
   authenticate,
   authorize([UserRole.ADMIN, UserRole.MANAGER, UserRole.CASHIER]),
-  (req, res, next): void => {
+  (req: Request, res: Response, next: NextFunction): void => {
     receiptController.generateReceipt.bind(receiptController)(req, res, next);
   }
 );
@@ -22,7 +22,7 @@ router.post(
   '/:saleId/send',
   authenticate,
   authorize([UserRole.ADMIN, UserRole.MANAGER, UserRole.CASHIER]),
-  (req, res, next): void => {
+  (req: Request, res: Response, next: NextFunction): void => {
     receiptController.sendReceipt.bind(receiptController)(req, res, next);
   }
 );
@@ -32,7 +32,7 @@ router.get(
   '/:saleId/history',
   authenticate,
   authorize([UserRole.ADMIN, UserRole.MANAGER]),
-  (req, res, next): void => {
+  (req: Request, res: Response, next: NextFunction): void => {
     receiptController.getReceiptHistory.bind(receiptController)(req, res, next);
   }
 );

--- a/backend/src/routes/report.routes.ts
+++ b/backend/src/routes/report.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { ReportController } from '../controllers/report.controller';
 import { authenticate } from '../middleware/auth.middleware';
 import { authorize } from '../middleware/authorize.middleware';
@@ -20,7 +20,7 @@ router.post(
   '/',
   authenticate,
   validate(reportValidation.generateReport),
-  (req, res, next): void => {
+  (req: Request, res: Response, next: NextFunction): void => {
     reportController.generateReport(req, res, next);
   }
 );
@@ -30,7 +30,7 @@ router.get(
   '/',
   authenticate,
   validate(reportValidation.getReports),
-  (req, res, next): void => {
+  (req: Request, res: Response, next: NextFunction): void => {
     reportController.getReports(req, res, next);
   }
 );

--- a/backend/src/routes/sale.routes.ts
+++ b/backend/src/routes/sale.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { protect, authorize } from '../middleware/auth.middleware';
 import { UserRole } from '../types/user';
 import {
@@ -27,15 +27,15 @@ router.use(protect);
 
 
 // Routes accessible by all authenticated users
-router.get('/', validate(getSalesValidation), (req, res, next): void => {
+router.get('/', validate(getSalesValidation), (req: Request, res: Response, next: NextFunction): void => {
   getSales(req, res, next);
 });
 
-router.get('/stats', (req, res, next): void => {
+router.get('/stats', (req: Request, res: Response, next: NextFunction): void => {
   getSalesStats(req, res, next);
 });
 
-router.get('/:id', (req, res, next): void => {
+router.get('/:id', (req: Request, res: Response, next: NextFunction): void => {
   getSale(req, res, next);
 });
 
@@ -91,15 +91,15 @@ router
     cancelSale
   );
 
-router.post('/', validate(createSaleValidation), (req, res, next): void => {
+router.post('/', validate(createSaleValidation), (req: Request, res: Response, next: NextFunction): void => {
   createSale(req, res, next);
 });
 
-router.patch('/:id/cancel', validate(cancelSaleValidation), (req, res, next): void => {
+router.patch('/:id/cancel', validate(cancelSaleValidation), (req: Request, res: Response, next: NextFunction): void => {
   cancelSale(req, res, next);
 });
 
-router.post('/:id/payments', validate(addPaymentValidation), (req, res, next): void => {
+router.post('/:id/payments', validate(addPaymentValidation), (req: Request, res: Response, next: NextFunction): void => {
   addPayment(req, res, next);
 });
 

--- a/backend/src/routes/scheduled-report.routes.ts
+++ b/backend/src/routes/scheduled-report.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { ScheduledReportController } from '../controllers/scheduled-report.controller';
 import { authenticate } from '../middleware/auth.middleware';
 import { authorize } from '../middleware/authorize.middleware';
@@ -14,7 +14,7 @@ router.post(
   authenticate,
   authorize(['ADMIN', 'MANAGER']),
   validate(scheduledReportValidation.scheduleReport),
-  (req, res, next): void => {
+  (req: Request, res: Response, next: NextFunction): void => {
     scheduledReportController.scheduleReport.bind(scheduledReportController)(req, res, next);
   }
 );
@@ -25,7 +25,7 @@ router.delete(
   authenticate,
   authorize(['ADMIN']),
   validate(scheduledReportValidation.cancelScheduledReport),
-  (req, res, next): void => {
+  (req: Request, res: Response, next: NextFunction): void => {
     scheduledReportController.cancelScheduledReport.bind(scheduledReportController)(req, res, next);
   }
 );
@@ -36,7 +36,7 @@ router.get(
   authenticate,
   authorize(['ADMIN', 'MANAGER']),
   validate(scheduledReportValidation.getScheduledReports),
-  (req, res, next): void => {
+  (req: Request, res: Response, next: NextFunction): void => {
     scheduledReportController.getScheduledReports.bind(scheduledReportController)(req, res, next);
   }
 );

--- a/backend/src/routes/sync.routes.ts
+++ b/backend/src/routes/sync.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { SyncController } from '../controllers/sync.controller';
 import { authenticate } from '../middleware/auth.middleware';
 import { authorize } from '../middleware/authorize.middleware';
@@ -14,7 +14,7 @@ router.post(
   authenticate,
   authorize(['ADMIN', 'MANAGER']),
   validate(syncValidation.syncData),
-  (req, res, next): void => {
+  (req: Request, res: Response, next: NextFunction): void => {
     syncController.syncData.bind(syncController)(req, res, next);
   }
 );
@@ -24,7 +24,7 @@ router.get(
   authenticate,
   authorize(['ADMIN', 'MANAGER']),
   validate(syncValidation.getSyncStatus),
-  (req, res, next): void => {
+  (req: Request, res: Response, next: NextFunction): void => {
     syncController.getSyncStatus.bind(syncController)(req, res, next);
   }
 );
@@ -34,7 +34,7 @@ router.post(
   authenticate,
   authorize(['ADMIN']),
   validate(syncValidation.cancelSync),
-  (req, res, next): void => {
+  (req: Request, res: Response, next: NextFunction): void => {
     syncController.cancelSync.bind(syncController)(req, res, next);
   }
 );

--- a/backend/src/routes/validation.routes.ts
+++ b/backend/src/routes/validation.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { ValidationController } from '../controllers/validation.controller';
 import { validateRequest } from '../middleware/validation';
 import { validationValidation } from '../validations/validation.validation';
@@ -15,7 +15,7 @@ router.post(
   authenticate,
   authorize([UserRole.ADMIN, UserRole.MANAGER]),
   validateRequest(validationValidation.validateData),
-  (req, res, next): void => {
+  (req: Request, res: Response, next: NextFunction): void => {
     validationController.validateData.bind(validationController)(req, res, next);
   }
 );
@@ -25,7 +25,7 @@ router.get(
   '/status',
   authenticate,
   authorize([UserRole.ADMIN, UserRole.MANAGER]),
-  (req, res, next): void => {
+  (req: Request, res: Response, next: NextFunction): void => {
     validationController.getValidationStatus.bind(validationController)(req, res, next);
   }
 );


### PR DESCRIPTION
## Summary
- type express route handler params with `Request`, `Response` and `NextFunction`

## Testing
- `npx tsc -p tsconfig.json` *(fails: 'catch' or 'finally' expected)*

------
https://chatgpt.com/codex/tasks/task_e_68521f480a548330b46b2193ebdda72a