### PR TITLE
Add simplified dashboard view

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Or run everything with Docker Compose:
 bash
 docker-compose up --build
 
+Once running, administrators can access a simplified dashboard at `/dashboard` for easy navigation.
+
 
 ## Installation
 

--- a/frontend/src/components/SimplifiedDashboard.tsx
+++ b/frontend/src/components/SimplifiedDashboard.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Box, Typography, Grid, Card, CardActionArea, CardContent } from '@mui/material';
+import { Dashboard as DashboardIcon, People as PeopleIcon, Description as DescriptionIcon } from '@mui/icons-material';
+import { Link as RouterLink } from 'react-router-dom';
+
+/**
+ * Simplified dashboard with quick access cards to main admin sections.
+ * Designed for users with basic computer skills.
+ */
+const SimplifiedDashboard: React.FC = () => {
+  const cards = [
+    { icon: <DashboardIcon fontSize="large" />, label: 'Notificações', to: '/admin/notifications' },
+    { icon: <PeopleIcon fontSize="large" />, label: 'Usuários', to: '/admin/users' },
+    { icon: <DescriptionIcon fontSize="large" />, label: 'Templates', to: '/admin/templates' }
+  ];
+
+  return (
+    <Box p={3} textAlign="center">
+      <Typography variant="h4" gutterBottom>
+        Painel Simplificado
+      </Typography>
+      <Grid container spacing={3} justifyContent="center">
+        {cards.map(({ icon, label, to }) => (
+          <Grid item xs={12} sm={6} md={4} key={label}>
+            <Card>
+              <CardActionArea component={RouterLink} to={to}>
+                <CardContent>
+                  <Box display="flex" flexDirection="column" alignItems="center" justifyContent="center" p={2}>
+                    {icon}
+                    <Typography variant="h6" mt={1}>
+                      {label}
+                    </Typography>
+                  </Box>
+                </CardContent>
+              </CardActionArea>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+  );
+};
+
+export default SimplifiedDashboard;

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../hooks/useAuth';
 import NotificationDashboard from '../components/NotificationDashboard';
 import UserManagement from '../components/UserManagement';
 import TemplateManagement from '../components/TemplateManagement';
+import SimplifiedDashboard from '../components/SimplifiedDashboard';
 
 const AppRoutes: React.FC = () => {
   const { isAuthenticated, user } = useAuth();
@@ -11,6 +12,9 @@ const AppRoutes: React.FC = () => {
   return (
     <Router>
       <Routes>
+        {/* Simplified dashboard for basic users */}
+        <Route path="/dashboard" element={<SimplifiedDashboard />} />
+
         {/* ... existing routes ... */}
         
         {/* Admin routes */}


### PR DESCRIPTION
## Summary
- add a SimplifiedDashboard component for quick admin navigation
- expose new `/dashboard` route
- document simplified dashboard usage in README

## Testing
- `npm test` *(fails: Cannot find module 'react/jsx-runtime'...)*

------
https://chatgpt.com/codex/tasks/task_e_68522ab8c97083308125dc0933eb16b9