### PR TITLE
Fix logger import and improve Jest module resolution

### DIFF
--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -1,4 +1,4 @@
-import * as winston from 'winston';
+import winston from 'winston';
 import { StreamOptions } from 'morgan';
 
 // Define colors

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,7 +24,7 @@ export default {
 
   ],
   verbose: true,
-  moduleDirectories: ['node_modules', 'backend/src'],
+  moduleDirectories: ['node_modules', 'backend/src', 'frontend/node_modules'],
   testPathIgnorePatterns: ['/node_modules/', '/dist/'],
   globals: {
     'ts-jest': {


### PR DESCRIPTION
## Summary
- adjust winston import to default syntax
- ensure Jest resolves modules from frontend node_modules

## Testing
- `npm test` *(fails: jest suites failing)*

------
https://chatgpt.com/codex/tasks/task_e_6852ccc82bf08330a4b74cda0d0cec04